### PR TITLE
Use snprintf to prevent buffer overrun

### DIFF
--- a/spidermonkey.c
+++ b/spidermonkey.c
@@ -534,7 +534,7 @@ rb_smjs_raise_ruby( JSContext* cx ){
 
     cs->last_exception = 0;
     strncpy( tmpmsg, cs->last_message, BUFSIZ );
-    sprintf( cs->last_message, "Exception already passed to Ruby: %s", tmpmsg );
+    snprintf( cs->last_message, BUFSIZ, "Exception already passed to Ruby: %s", tmpmsg );
   }
 
   JS_AddNamedRoot( cx, &jsvalerror, "rb_smjs_raise_ruby" );


### PR DESCRIPTION
Based on my reading of this line, it looks like we're copying `last_message` into `tmpmsg`, which is of size `BUFSIZ`. Then we take `tmpmsg` and write it back into `last_message`, _but with a prefix_... so the prefix could conceivably add enough length to overrun the end of the `last_message` buffer.

I think changing it to `snprintf` will help prevent this. I haven't built and run this code yet, it just stuck out to me when I was poking through.